### PR TITLE
Add input validation for exam score number fields

### DIFF
--- a/serve_website.py
+++ b/serve_website.py
@@ -257,7 +257,9 @@ def exam_page(course):
             ui.label(course['label']).classes('text-lg font-semibold text-cyan-400 mb-2')
             ui.label(course['subtitle']).classes('text-sm text-gray-500 mb-4')
             ui.number(label='Score', placeholder=course['placeholder'],
-                      on_change=update_results).classes('w-full text-lg')
+                      on_change=update_results,
+                      validation={'Out of range': lambda v: v is not None and 0 <= v <= 100},
+                      ).classes('w-full text-lg')
 
         results_card = ui.card().classes('w-full p-8 rounded-2xl mt-4 bg-gray-900 border border-gray-800')
         results_card.set_visibility(False)


### PR DESCRIPTION
## Summary
- Adds `validation` parameter to the exam page `ui.number` field
- Rejects out-of-range values (must be 0-100), matching the GPA page's validation pattern

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)