### PR TITLE
Run Docker container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+RUN useradd --create-home appuser
+USER appuser
+
 EXPOSE 8080
 
 CMD ["python", "serve_website.py"]


### PR DESCRIPTION
## Summary
- Creates a non-root `appuser` in the Dockerfile
- Switches to `appuser` before `EXPOSE` and `CMD` for improved container security

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)