### PR TITLE
Add comment explaining fractional bin counts in COMP2012H

### DIFF
--- a/serve_website.py
+++ b/serve_website.py
@@ -39,6 +39,7 @@ EXAM_COURSES = [
         'label': 'Enter your midterm score',
         'placeholder': 'e.g. 75',
         'total_students': 53,
+        # Some histogram bars fell between horizontal gridlines, giving fractional counts
         'bin_counts': [0, 0, 0, 0, 0, 1, 1, 1, 1, 3, 3, 5, 3, 2, 13, 6.5, 1.5, 4.5, 4.5, 1.5, 1.5],
         'score_step': 5,
         'interp_step': 0.25,


### PR DESCRIPTION
## Summary
- Adds a comment above the COMP2012H `bin_counts` explaining that fractional values (6.5, 1.5, etc.) arise because some histogram bars fell between the horizontal gray lines

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)