### PR TITLE
Remove unnecessary str() wrapping in nav_bar

### DIFF
--- a/serve_website.py
+++ b/serve_website.py
@@ -111,7 +111,7 @@ def page_header(title, subtitle=None):
 
 
 def nav_bar():
-    items = [('GPA Rank', '/')] + [(str(c['nav_label']), str(c['route'])) for c in EXAM_COURSES]
+    items = [('GPA Rank', '/')] + [(c['nav_label'], c['route']) for c in EXAM_COURSES]
     with ui.row().classes('w-full max-w-2xl mx-auto gap-2 flex-wrap justify-center mb-6'):
         for label, href in items:
             ui.link(label, href).classes(


### PR DESCRIPTION
## Summary
- Removes redundant `str()` calls around `c['nav_label']` and `c['route']` in `nav_bar()` since these values are already strings

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)